### PR TITLE
fix: fix graceful cancellation and detection of modified content.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 #### Changed
 
 * Changed the default parallelism to 4 times the available parallelism ([#2](https://github.com/stjude-rust-labs/cloud-copy/pull/2)).
+
+#### Fixed
+
+* Fixed remote content modification check with ranged downloads to use the
+  `if-match` header ([#3](https://github.com/stjude-rust-labs/cloud-copy/pull/3)).
+* Fixed graceful cancellation (i.e. SIGINT) to cancel operations without
+  retrying and return a non-zero exit ([#3](https://github.com/stjude-rust-labs/cloud-copy/pull/3)).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -518,7 +518,7 @@ pub async fn copy(
 #[cfg_attr(docsrs, doc(cfg(feature = "cli")))]
 pub async fn handle_events(
     mut events: broadcast::Receiver<TransferEvent>,
-    mut shutdown: tokio::sync::oneshot::Receiver<()>,
+    cancel: CancellationToken,
 ) {
     use std::collections::HashMap;
 
@@ -549,7 +549,7 @@ pub async fn handle_events(
 
     loop {
         tokio::select! {
-            _ = &mut shutdown => break,
+            _ = cancel.cancelled() => break,
             event = events.recv() => match event {
                 Ok(TransferEvent::TransferStarted { id, path, size, .. }) => {
                     let bar = warn_span!("progress");

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -504,7 +504,7 @@ where
 
         // Check to see if we can download the file with blocks
         // For block downloads, the server must have responded with the resource size,
-        // accept byte ranges, and provided a strong etag.
+        // accept byte ranges, and provided a strong etag (does not start with `W/`).
         let result = match (file_size, accept_ranges, etag) {
             (Some(file_size), Some("bytes"), Some(etag)) if !etag.starts_with("W/") => {
                 // Calculate the block size and the number of blocks to download


### PR DESCRIPTION
This PR fixes graceful cancellation such that it now prevents retries from occurring if cancellation occurs during a retryable operation.

It both prevents the retries and the warnings that get printed when a retry occurs; it now properly displays a "operation canceled" error message and exits with a non-zero status.

Additionally, the `if-range` header was removed on conditional ranged requests in favor of `if-match` as some of the storage backends didn't respect the `if-range` header.

Also added a check to ensure the ETag returned from the server is a "strong" tag.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
