### PR TITLE
feat: implement emulator tests.

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,6 +34,23 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@v4
+      - name: Start LocalStack (AWS S3)
+        uses: LocalStack/setup-localstack@v0.2.2
+        with:
+          image-tag: 'latest-s3'
+          install-awslocal: 'true'
+      - name: Start Azurite (Azure Storage)
+        uses: potatoqualitee/azuright@v1.1
+        with:
+          loose: true
+      - name: Create test AWS S3 bucket
+        run: awslocal s3api create-bucket --bucket cloud-copy-test
+      - name: Create test Azure Storage container
+        uses: azure/cli@v2
+        with:
+          azcliversion: latest
+          inlineScript: |
+            az storage container create --name cloud-copy-test --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1"
       - name: Update Rust
         run: rustup update stable && rustup default stable
       - run: cargo test --all-features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added testing with emulators Azurite and localstack ([#4](https://github.com/stjude-rust-labs/cloud-copy/pull/4)).
 * Added initial implementation of `cloud-copy` ([#1](https://github.com/stjude-rust-labs/cloud-copy/pull/1)).
 
 #### Changed
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed a panic when running `cloud-copy` ([#4](https://github.com/stjude-rust-labs/cloud-copy/pull/4)).
 * Fixed remote content modification check with ranged downloads to use the
   `if-match` header ([#3](https://github.com/stjude-rust-labs/cloud-copy/pull/3)).
 * Fixed graceful cancellation (i.e. SIGINT) to cancel operations without

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,9 @@ url = { version = "2.5.4", features = ["serde"] }
 urlencoding = "2.1.3"
 walkdir = "2.5.0"
 
+[dev-dependencies]
+anyhow = { version = "1.0.98" }
+
 [lints.rust]
 missing_docs = "warn"
 nonstandard-style = "warn"

--- a/README.md
+++ b/README.md
@@ -127,7 +127,46 @@ path to copy the file or directory to.
 
 ## 🧠 Running Automated Tests
 
-This section coming soon!
+Automated tests rely on having the following cloud service emulators installed:
+
+* [Azurite](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azurite?tabs=visual-studio%2Cblob-storage)
+  for Azure Blob Storage.
+* [Localstack](https://github.com/localstack/localstack) for AWS S3.
+
+Use the following command to run Azurite in a Docker container:
+
+```bash
+docker run -p 10000:10000 mcr.microsoft.com/azure-storage/azurite azurite -l /data --blobHost 0.0.0.0 --loose
+```
+
+Use the following command to run Localstack in a Docker container:
+
+```bash
+docker run -p 4566:4566 localstack/localstack:s3-latest
+```
+
+The tests expect a container/bucket with the name `cloud-copy-test` to be
+present.
+
+To create the container with Azurite, use the Azure CLI:
+
+```bash
+az storage container create --name cloud-copy-test --connection-string "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1"
+```
+
+To create the bucket with Localstack, use the `awslocal` tool:
+
+```bash
+awslocal s3api create-bucket --bucket cloud-copy-test
+```
+
+Finally, run the tests:
+
+```bash
+cargo test --all
+```
+
+Note: the Azure tests expect `blob.localhost` to resolve to `127.0.0.1`.
 
 ## ✅ Submitting Pull Requests
 

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -50,6 +50,16 @@ pub trait StorageBackend {
     /// Gets the block size given the size of a file.
     fn block_size(&self, file_size: u64) -> Result<u64>;
 
+    /// Whether or not the URL is supported by this backend.
+    fn is_supported_url(url: &Url) -> bool;
+
+    /// Rewrites the given URL.
+    ///
+    /// If the URL is using a cloud-specific scheme, the URL is rewritten to a `https` schemed URL.
+    ///
+    /// Otherwise, the given URL is returned as-is.
+    fn rewrite_url(&self, url: Url) -> Result<Url>;
+
     /// Joins segments to a URL to form a new URL.
     fn join_url<'a>(&self, url: Url, segments: impl Iterator<Item = &'a str>) -> Result<Url>;
 

--- a/src/backend/generic.rs
+++ b/src/backend/generic.rs
@@ -108,6 +108,14 @@ impl StorageBackend for GenericStorageBackend {
         Ok(4 * 1024 * 1024)
     }
 
+    fn is_supported_url(_: &Url) -> bool {
+        true
+    }
+
+    fn rewrite_url(&self, url: Url) -> Result<Url> {
+        Ok(url)
+    }
+
     fn join_url<'a>(&self, mut url: Url, segments: impl Iterator<Item = &'a str>) -> Result<Url> {
         // Append on the segments
         {

--- a/src/backend/google.rs
+++ b/src/backend/google.rs
@@ -41,7 +41,7 @@ use crate::streams::ByteStream;
 use crate::streams::TransferStream;
 
 /// The root domain for Google Cloud Storage.
-pub const GOOGLE_ROOT_DOMAIN: &str = "storage.googleapis.com";
+const GOOGLE_ROOT_DOMAIN: &str = "storage.googleapis.com";
 
 /// The maximum number of parts in an upload.
 const MAX_PARTS: u64 = 10000;
@@ -152,73 +152,6 @@ fn append_authentication_header(
         HeaderValue::try_from(auth).expect("value should be valid"),
     );
     Ok(())
-}
-
-/// Determines if the given URL is a Google Cloud Storage URL.
-pub fn is_gcs_url(url: &Url) -> bool {
-    match url.scheme() {
-        "gs" => true,
-        "https" => {
-            let Some(domain) = url.domain() else {
-                return false;
-            };
-
-            if domain.eq_ignore_ascii_case(GOOGLE_ROOT_DOMAIN) {
-                // Path-style URL of the form http://storage.googleapis.com/<bucket>/<object>
-                // There must be at least two path segments
-                return url
-                    .path_segments()
-                    .map(|mut s| s.nth(1).is_some())
-                    .unwrap_or(false);
-            }
-
-            // Virtual host style URL of the form https://<bucket>.storage.googleapis.com/<object>
-            let Some((bucket, domain)) = domain.split_once('.') else {
-                return false;
-            };
-
-            // There must be at least one path segment
-            !bucket.is_empty()
-                && domain.eq_ignore_ascii_case(GOOGLE_ROOT_DOMAIN)
-                && url
-                    .path_segments()
-                    .map(|mut s| s.next().is_some())
-                    .unwrap_or(false)
-        }
-        _ => false,
-    }
-}
-
-/// Rewrites a Google Cloud Storage URL (gs://) into a HTTPS URL.
-///
-/// If the URL is not `gs` schemed, the given URL is returned as-is.
-pub fn rewrite_url(url: Url) -> Result<Url> {
-    match url.scheme() {
-        "gs" => {
-            let bucket = url.host_str().ok_or(GoogleError::InvalidScheme)?;
-            let path = url.path();
-
-            if url.path() == "/" {
-                return Err(GoogleError::InvalidScheme.into());
-            }
-
-            match (url.query(), url.fragment()) {
-                (None, None) => format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}"),
-                (None, Some(fragment)) => {
-                    format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}#{fragment}")
-                }
-                (Some(query), None) => {
-                    format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}?{query}")
-                }
-                (Some(query), Some(fragment)) => {
-                    format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}?{query}#{fragment}")
-                }
-            }
-            .parse()
-            .map_err(|_| GoogleError::InvalidScheme.into())
-        }
-        _ => Ok(url),
-    }
 }
 
 /// URL extensions for Google Cloud Storage.
@@ -523,6 +456,69 @@ impl StorageBackend for GoogleStorageBackend {
         Ok(block_size)
     }
 
+    fn is_supported_url(url: &Url) -> bool {
+        match url.scheme() {
+            "gs" => true,
+            "http" | "https" => {
+                let Some(domain) = url.domain() else {
+                    return false;
+                };
+
+                if domain.eq_ignore_ascii_case(GOOGLE_ROOT_DOMAIN) {
+                    // Path-style URL of the form http://storage.googleapis.com/<bucket>/<object>
+                    // There must be at least two path segments
+                    return url
+                        .path_segments()
+                        .map(|mut s| s.nth(1).is_some())
+                        .unwrap_or(false);
+                }
+
+                // Virtual host style URL of the form https://<bucket>.storage.googleapis.com/<object>
+                let Some((bucket, domain)) = domain.split_once('.') else {
+                    return false;
+                };
+
+                // There must be at least one path segment
+                !bucket.is_empty()
+                    && domain.eq_ignore_ascii_case(GOOGLE_ROOT_DOMAIN)
+                    && url
+                        .path_segments()
+                        .map(|mut s| s.next().is_some())
+                        .unwrap_or(false)
+            }
+            _ => false,
+        }
+    }
+
+    fn rewrite_url(&self, url: Url) -> Result<Url> {
+        match url.scheme() {
+            "gs" => {
+                let bucket = url.host_str().ok_or(GoogleError::InvalidScheme)?;
+                let path = url.path();
+
+                if url.path() == "/" {
+                    return Err(GoogleError::InvalidScheme.into());
+                }
+
+                match (url.query(), url.fragment()) {
+                    (None, None) => format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}"),
+                    (None, Some(fragment)) => {
+                        format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}#{fragment}")
+                    }
+                    (Some(query), None) => {
+                        format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}?{query}")
+                    }
+                    (Some(query), Some(fragment)) => {
+                        format!("https://{bucket}.{GOOGLE_ROOT_DOMAIN}{path}?{query}#{fragment}")
+                    }
+                }
+                .parse()
+                .map_err(|_| GoogleError::InvalidScheme.into())
+            }
+            _ => Ok(url),
+        }
+    }
+
     fn join_url<'a>(&self, mut url: Url, segments: impl Iterator<Item = &'a str>) -> Result<Url> {
         // Append on the segments
         {
@@ -536,8 +532,9 @@ impl StorageBackend for GoogleStorageBackend {
 
     async fn head(&self, url: Url) -> Result<Response> {
         debug_assert!(
-            is_gcs_url(&url) && url.scheme() == "https",
-            "expected Google Cloud Storage HTTPS URL"
+            Self::is_supported_url(&url),
+            "{url} is not a supported GCS URL",
+            url = url.as_str()
         );
 
         debug!("sending HEAD request for `{url}`", url = url.display());
@@ -568,8 +565,9 @@ impl StorageBackend for GoogleStorageBackend {
 
     async fn get(&self, url: Url) -> Result<Response> {
         debug_assert!(
-            is_gcs_url(&url) && url.scheme() == "https",
-            "expected Google Cloud Storage HTTPS URL"
+            Self::is_supported_url(&url),
+            "{url} is not a supported GCS URL",
+            url = url.as_str()
         );
 
         debug!("sending GET request for `{url}`", url = url.display());
@@ -600,8 +598,9 @@ impl StorageBackend for GoogleStorageBackend {
 
     async fn get_range(&self, url: Url, etag: &str, range: Range<u64>) -> Result<Response> {
         debug_assert!(
-            is_gcs_url(&url) && url.scheme() == "https",
-            "expected Google Cloud Storage HTTPS URL"
+            Self::is_supported_url(&url),
+            "{url} is not a supported GCS URL",
+            url = url.as_str()
         );
 
         debug!(
@@ -658,8 +657,9 @@ impl StorageBackend for GoogleStorageBackend {
         // See: https://cloud.google.com/storage/docs/xml-api/get-bucket-list
 
         debug_assert!(
-            is_gcs_url(&url) && url.scheme() == "https",
-            "expected Google Cloud Storage HTTPS URL"
+            Self::is_supported_url(&url),
+            "{url} is not a supported GCS URL",
+            url = url.as_str()
         );
 
         debug!("walking `{url}` as a directory", url = url.display());
@@ -754,8 +754,9 @@ impl StorageBackend for GoogleStorageBackend {
         // See: https://cloud.google.com/storage/docs/xml-api/post-object-multipart
 
         debug_assert!(
-            is_gcs_url(&url) && url.scheme() == "https",
-            "expected Google Cloud Storage HTTPS URL"
+            Self::is_supported_url(&url),
+            "{url} is not a supported GCS URL",
+            url = url.as_str()
         );
 
         debug!("sending POST request for `{url}`", url = url.display());
@@ -764,6 +765,10 @@ impl StorageBackend for GoogleStorageBackend {
         create.query_pairs_mut().append_key_only("uploads");
 
         let date = Utc::now();
+
+        create.set_scheme("http").unwrap();
+        create.set_ip_host("127.0.0.1".parse().unwrap()).unwrap();
+        create.set_port(Some(9000)).unwrap();
 
         let mut request = self
             .client

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -3,7 +3,6 @@
 use std::fmt;
 
 use rand::Rng as _;
-use rand::rngs::ThreadRng;
 
 /// An alphanumeric string generator.
 ///
@@ -30,7 +29,7 @@ impl Default for Alphanumeric {
 
 impl fmt::Display for Alphanumeric {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for c in ThreadRng::default()
+        for c in rand::rng()
             .sample_iter(&rand::distr::Alphanumeric)
             .take(self.length)
             .map(|c| c.to_ascii_lowercase())

--- a/src/main.rs
+++ b/src/main.rs
@@ -238,6 +238,8 @@ async fn main() {
 
                     std::process::exit(1);
                 }
+
+                break;
             }
         }
     }

--- a/tests/copy.rs
+++ b/tests/copy.rs
@@ -1,0 +1,389 @@
+//! Tests for `cloud_copy::copy`.
+
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::bail;
+use cloud_copy::Alphanumeric;
+use cloud_copy::Config;
+use cloud_copy::S3AuthConfig;
+use cloud_copy::S3Config;
+use futures::FutureExt;
+use futures::future::LocalBoxFuture;
+use rand::Rng;
+use tempfile::NamedTempFile;
+use tempfile::tempdir;
+use tokio::io::AsyncReadExt;
+use tokio::io::AsyncWriteExt;
+use tokio::io::BufReader;
+use tokio::{fs::File, io::BufWriter};
+use tokio_util::sync::CancellationToken;
+use url::Url;
+use walkdir::WalkDir;
+
+/// Represents 1 MiB (in bytes).
+const ONE_MEBIBYTE: usize = 1024 * 1024;
+
+/// The test container/bucket name.
+const TEST_BUCKET_NAME: &str = "cloud-copy-test";
+
+/// Writes random bytes of the given size to the given file.
+async fn write_random_bytes(file: File, mut size: usize) -> Result<()> {
+    let mut rng = rand::rng();
+    let mut buffer = [0; 4096];
+
+    let mut writer = BufWriter::new(file);
+    while size > 0 {
+        let to_write = size.min(buffer.len());
+        let buffer = &mut buffer[..to_write];
+        rng.fill(buffer);
+        size -= writer
+            .write(buffer)
+            .await
+            .context("failed to write random file")?;
+    }
+
+    Ok(())
+}
+
+/// Determines if two files have the same content.
+async fn same_file_content(first: &Path, second: &Path) -> Result<bool> {
+    if first
+        .metadata()
+        .context("failed to read metadata of first file")?
+        .len()
+        != second
+            .metadata()
+            .context("failed to read metadata of second file")?
+            .len()
+    {
+        return Ok(false);
+    }
+
+    let mut first = BufReader::new(
+        File::open(first)
+            .await
+            .context("failed to open first file for comparison")?,
+    );
+    let mut second = BufReader::new(
+        File::open(second)
+            .await
+            .context("failed to open second file for comparison")?,
+    );
+
+    let mut first_buffer = [0; 4096];
+    let mut second_buffer = [0; 4096];
+
+    loop {
+        let read = first
+            .read(&mut first_buffer)
+            .await
+            .context("failed to read first file for comparison")?;
+        if read == 0 {
+            break;
+        }
+
+        second
+            .read_exact(&mut second_buffer[0..read])
+            .await
+            .context("failed to read first file for comparison")?;
+
+        if first_buffer != second_buffer {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+/// Creates random files in a directory.
+fn create_random_files<'a>(dir: &'a Path, depth: usize) -> LocalBoxFuture<'a, Result<()>> {
+    async move {
+        let mut rng = rand::rng();
+
+        for i in 0..5 {
+            let file = File::create(dir.join(format!("file-{i}")))
+                .await
+                .context("failed to create test file")?;
+            let size = { rng.random_range(0..ONE_MEBIBYTE) };
+            write_random_bytes(file, size).await?;
+        }
+
+        if depth > 0 {
+            let subdir = dir.join(format!("dir-{depth}"));
+            fs::create_dir(&subdir).context("failed to create test directory")?;
+            create_random_files(&subdir, depth - 1).await?;
+        }
+
+        Ok(())
+    }
+    .boxed_local()
+}
+
+/// Walks a directory and returns a sorted list of its entries.
+///
+/// The returns paths are relative to the given directory.
+fn walk_dir(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut entries = Vec::new();
+
+    for entry in WalkDir::new(dir) {
+        let entry = entry.context("failed to walk directory")?;
+        entries.push(
+            entry
+                .path()
+                .strip_prefix(dir)
+                .context("failed to strip directory prefix")?
+                .to_path_buf(),
+        );
+    }
+
+    entries.sort();
+    Ok(entries)
+}
+
+/// Gets a set of cloud storage URLs to test given the test name.
+fn urls(test: &str) -> Vec<Url> {
+    vec![
+        // S3 URLs
+        format!("s3://{TEST_BUCKET_NAME}/1/{test}").parse().unwrap(),
+        format!("https://s3.us-east-1.amazonaws.com/{TEST_BUCKET_NAME}/2/{test}")
+            .parse()
+            .unwrap(),
+        format!("https://{TEST_BUCKET_NAME}.s3.us-east-1.amazonaws.com/3/{test}")
+            .parse()
+            .unwrap(),
+
+        // Azure URLs
+        // These URLs use a SAS token that expires in 2050 and the default credentials of Azurite
+        format!("az://devstoreaccount1/{TEST_BUCKET_NAME}/1/{test}?sv=2018-03-28&spr=https%2Chttp&st=2025-08-11T15%3A49%3A59Z&se=2050-08-11T15%3A49%3A00Z&sr=c&sp=rcwl&sig=0UK1EckCkj0k8Xi7s7yjB5QpjZa%2FVUmtd906SWAtO%2FM%3D").parse().unwrap(),
+        format!("https://devstoreaccount1.blob.core.windows.net/{TEST_BUCKET_NAME}/2/{test}?sv=2018-03-28&spr=https%2Chttp&st=2025-08-11T15%3A49%3A59Z&se=2050-08-11T15%3A49%3A00Z&sr=c&sp=rcwl&sig=0UK1EckCkj0k8Xi7s7yjB5QpjZa%2FVUmtd906SWAtO%2FM%3D").parse().unwrap(),
+    ]
+}
+
+fn config() -> Config {
+    Config {
+        s3: S3Config {
+            auth: Some(S3AuthConfig {
+                access_key_id: "test".to_string(),
+                secret_access_key: "test".into(),
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    }
+}
+
+/// Round trips a file of a given size by uploading it to cloud storage and then downloading it again.
+async fn roundtrip_file(test: &str, size: usize) -> Result<()> {
+    let config = config();
+    let cancel = CancellationToken::new();
+
+    // Create a new temp file of the specified size
+    let (file, source) = NamedTempFile::new()
+        .context("failed to create temp file")?
+        .into_parts();
+    write_random_bytes(file.into(), size)
+        .await
+        .context("failed to write random bytes into file")?;
+
+    // Create another temporary file path for the download
+    let destination = NamedTempFile::new()
+        .context("failed to create temp file")?
+        .into_temp_path();
+
+    for url in urls(test) {
+        // Copy the local file to the cloud
+        cloud_copy::copy(config.clone(), &*source, url.clone(), cancel.clone(), None)
+            .await
+            .context("failed to upload file")?;
+
+        // Copy the file from the cloud to a local file (delete it first in case it exists)
+        fs::remove_file(&destination).context("failed to delete destination file")?;
+        cloud_copy::copy(
+            config.clone(),
+            url.clone(),
+            &*destination,
+            cancel.clone(),
+            None,
+        )
+        .await
+        .context("failed to download file")?;
+
+        // Ensure the uploaded file and the downloaded file are the same
+        if !same_file_content(&source, &destination)
+            .await
+            .context("failed to compare files")?
+        {
+            bail!("the downloaded file is not equal to the uploaded");
+        }
+    }
+
+    Ok(())
+}
+
+/// Sets the environment variables for using the emulators.
+fn set_test_env() {
+    unsafe {
+        std::env::set_var("TEST_LOCALSTACK", "1");
+        std::env::set_var("TEST_AZURITE", "1");
+    }
+}
+
+/// A test to download a generic URL.
+#[tokio::test]
+async fn copy_generic_url() -> Result<()> {
+    // Create a temporary file path for the download
+    let destination = NamedTempFile::new()
+        .context("failed to create temp file")?
+        .into_temp_path();
+
+    fs::remove_file(&destination).context("failed to delete destination file")?;
+
+    // Copy the URL to the local file
+    let cancel = CancellationToken::new();
+    cloud_copy::copy(
+        config(),
+        "https://example.com",
+        &*destination,
+        cancel.clone(),
+        None,
+    )
+    .await
+    .context("failed to download file")?;
+
+    Ok(())
+}
+
+/// A test to roundtrip an empty file.
+#[tokio::test]
+async fn roundtrip_empty_file() -> Result<()> {
+    set_test_env();
+
+    let test = format!("{random}", random = Alphanumeric::new(10));
+    roundtrip_file(&test, 0).await
+}
+
+/// A test to roundtrip a small (1 byte to 10 MiB) file.
+#[tokio::test]
+async fn roundtrip_small_file() -> Result<()> {
+    set_test_env();
+
+    let test = format!("{random}", random = Alphanumeric::new(10));
+    roundtrip_file(&test, rand::rng().random_range(1..10 * ONE_MEBIBYTE)).await
+}
+
+/// A test to roundtrip a medium (10 MiB to 50 MiB) file.
+#[tokio::test]
+async fn roundtrip_medium_file() -> Result<()> {
+    set_test_env();
+
+    let test = format!("{random}", random = Alphanumeric::new(10));
+    roundtrip_file(
+        &test,
+        rand::rng().random_range(10 * ONE_MEBIBYTE..50 * ONE_MEBIBYTE),
+    )
+    .await
+}
+
+/// A test to roundtrip a large (50 MiB to 100 MiB) file.
+#[tokio::test]
+async fn roundtrip_large_file() -> Result<()> {
+    set_test_env();
+
+    let test = format!("{random}", random = Alphanumeric::new(10));
+    roundtrip_file(
+        &test,
+        rand::rng().random_range(50 * ONE_MEBIBYTE..100 * ONE_MEBIBYTE),
+    )
+    .await
+}
+
+/// A test to roundtrip a directory.
+#[tokio::test]
+async fn roundtrip_directory() -> Result<()> {
+    set_test_env();
+
+    let test = format!("{random}", random = Alphanumeric::new(10));
+
+    let source = tempdir().context("failed to create temporary directory")?;
+    let destination = tempdir().context("failed to create temporary directory")?;
+
+    create_random_files(source.path(), 3)
+        .await
+        .context("failed to populate temporary directory")?;
+
+    let config = config();
+    let cancel = CancellationToken::new();
+    for url in urls(&test) {
+        // Copy the local directory to the cloud
+        cloud_copy::copy(
+            config.clone(),
+            source.path(),
+            url.clone(),
+            cancel.clone(),
+            None,
+        )
+        .await
+        .context("failed to upload directory")?;
+
+        // Copy the directory from the cloud to a local directory (delete it first in case it exists)
+        fs::remove_dir_all(destination.path()).context("failed to delete destination directory")?;
+        cloud_copy::copy(
+            config.clone(),
+            url.clone(),
+            destination.path(),
+            cancel.clone(),
+            None,
+        )
+        .await
+        .context("failed to download directory")?;
+
+        let source_entries = walk_dir(source.path()).context("failed to walk source directory")?;
+        let destination_entries =
+            walk_dir(destination.path()).context("failed to walk destination directory")?;
+
+        if source_entries.len() != destination_entries.len() {
+            bail!("source directory and download directory have a different number of entries");
+        }
+
+        for (orig, new) in source_entries.into_iter().zip(destination_entries) {
+            if orig != new {
+                bail!(
+                    "original entry `{orig}` does not match the new entry `{new}`",
+                    orig = orig.display(),
+                    new = new.display()
+                );
+            }
+
+            let source = source.path().join(orig);
+            let destination = destination.path().join(new);
+
+            match (source.is_dir(), destination.is_dir()) {
+                (true, true) => continue,
+                (false, false) => {
+                    // Ensure the uploaded file and the downloaded file are the same
+                    if !same_file_content(&source, &destination)
+                        .await
+                        .context("failed to compare files")?
+                    {
+                        bail!(
+                            "contents of upo file `{source}` does not match the contents of downloaded file `{destination}`",
+                            source = source.display(),
+                            destination = destination.display()
+                        );
+                    }
+                }
+                _ => bail!(
+                    "source entry `{source}` does not match the type of download entry `{destination}`",
+                    source = source.display(),
+                    destination = destination.display()
+                ),
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR implements tests for the Azure Storage and AWS S3 backends to use local storage emulators for tests.

Also fixes a panic due to a missing `break` in `cloud-copy`'s main function that was caused by introducing a loop to drive the main future to completion upon cancellation.

Note that Google Cloud Storage tests were not added as there currently isn't an
officially supported emulator.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
