### PR TITLE
feat: implement link to cached files.

### DIFF
--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,6 +1,8 @@
 //! Implementation of storage backends.
 
 use bytes::Bytes;
+use http_cache_stream_reqwest::Cache;
+use http_cache_stream_reqwest::storage::DefaultCacheStorage;
 use reqwest::Response;
 use tokio::sync::broadcast;
 use url::Url;
@@ -41,6 +43,11 @@ pub trait StorageBackend {
 
     /// Gets the configuration used by the backend.
     fn config(&self) -> &Config;
+
+    /// Gets the HTTP cache used by the backend.
+    ///
+    /// Returns `None` if caching is not enabled.
+    fn cache(&self) -> Option<&Cache<DefaultCacheStorage>>;
 
     /// Gets the channel for sending transfer events.
     fn events(&self) -> &Option<broadcast::Sender<TransferEvent>>;

--- a/src/config.rs
+++ b/src/config.rs
@@ -88,6 +88,22 @@ pub struct Config {
     /// If `None`, downloads will not use a cache.
     #[serde(default)]
     pub cache_dir: Option<PathBuf>,
+    /// If `link_to_cache` is `true`, then a downloaded file that is already
+    /// present (and fresh) in the cache will be hard linked at the requested
+    /// destination instead of copied.
+    ///
+    /// If the creation of the hard link fails (for example, the cache exists on
+    /// a different file system than the destination path), then a copy to the
+    /// destination will be made instead.
+    ///
+    /// Note that cache files are created read-only; if the destination is
+    /// created as a hard link, it will also be read-only. It is not recommended
+    /// to make the destination writable as writing to the destination path
+    /// would corrupt the corresponding content entry in the cache.
+    ///
+    /// When `false`, a copy to the destination is always performed.
+    #[serde(default)]
+    pub link_to_cache: bool,
     /// The block size to use for file transfers.
     ///
     /// The default block size depends on the cloud storage service.

--- a/src/main.rs
+++ b/src/main.rs
@@ -101,6 +101,10 @@ struct Args {
     #[clap(long, value_name = "DIR")]
     cache_dir: Option<PathBuf>,
 
+    /// Whether or not to create hard links to existing cached files.
+    #[clap(long)]
+    link_to_cache: bool,
+
     /// The block size to use for file transfers; the default block size depends
     /// on the cloud service.
     #[clap(long, value_name = "SIZE")]
@@ -175,6 +179,7 @@ impl Args {
 
         let config = Config {
             cache_dir: self.cache_dir,
+            link_to_cache: self.link_to_cache,
             block_size: self.block_size,
             parallelism: self.parallelism,
             retries: self.retries,

--- a/src/streams.rs
+++ b/src/streams.rs
@@ -141,10 +141,34 @@ where
             }
             Poll::Ready(Some(Err(e))) => {
                 *this.finished = true;
+
+                // Send one last progress event
+                if let Some(events) = &this.events {
+                    events
+                        .send(TransferEvent::BlockProgress {
+                            id: *this.id,
+                            block: *this.block,
+                            transferred: *this.transferred,
+                        })
+                        .ok();
+                }
+
                 Poll::Ready(Some(Err(e)))
             }
             Poll::Ready(None) => {
                 *this.finished = true;
+
+                // Send one last progress event
+                if let Some(events) = &this.events {
+                    events
+                        .send(TransferEvent::BlockProgress {
+                            id: *this.id,
+                            block: *this.block,
+                            transferred: *this.transferred,
+                        })
+                        .ok();
+                }
+
                 Poll::Ready(None)
             }
             Poll::Pending => Poll::Pending,


### PR DESCRIPTION
This PR implements creating hard links to cached files instead of making copies.

If a hard link cannot be made, a copy is performed instead.

This PR also fixes the use case when `copy` is called to copy between local file paths (supported, although not particularly useful). The copy was being performed with a direct call to `fs::copy`, which did not emit any transfer events. As a result, the statistics printed at the end of the run was always 0 files copied, 0 bytes transferred.

The fix was to wrap the source file stream with a transfer stream so that transfer events are emitted and the statistics are then updated.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [ ] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
