### PR TITLE
feat: extract HTTP client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added `HttpClient` for allowing reuse of an HTTP client between copy
+  operations ([#7](https://github.com/stjude-rust-labs/cloud-copy/pull/7)).
 * Added support for linking files to the cache ([#6](https://github.com/stjude-rust-labs/cloud-copy/pull/6)).
 * Added statistics to the CLI upon successful copy ([#5](https://github.com/stjude-rust-labs/cloud-copy/pull/5)).
 * Added `--cache-dir` CLI option for download caching ([#5](https://github.com/stjude-rust-labs/cloud-copy/pull/5)).

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -13,7 +13,6 @@ use reqwest::Response;
 use reqwest::StatusCode;
 use reqwest::header;
 use reqwest::header::HeaderValue;
-use reqwest_middleware::ClientWithMiddleware;
 use secrecy::ExposeSecret;
 use serde::Deserialize;
 use serde::Serialize;
@@ -24,6 +23,7 @@ use url::Url;
 use crate::BLOCK_SIZE_THRESHOLD;
 use crate::Config;
 use crate::Error;
+use crate::HttpClient;
 use crate::ONE_MEBIBYTE;
 use crate::Result;
 use crate::S3AuthConfig;
@@ -35,7 +35,6 @@ use crate::backend::Upload;
 use crate::backend::auth::RequestSigner;
 use crate::backend::auth::SignatureProvider;
 use crate::backend::auth::sha256_hex_string;
-use crate::new_http_client;
 use crate::streams::ByteStream;
 use crate::streams::TransferStream;
 
@@ -334,7 +333,7 @@ pub struct S3Upload {
     /// The configuration to use for the upload.
     config: Arc<Config>,
     /// The HTTP client to use for uploading.
-    client: ClientWithMiddleware,
+    client: HttpClient,
     /// The URL of the object being uploaded.
     url: Url,
     /// The identifier of this upload.
@@ -464,23 +463,21 @@ pub struct S3StorageBackend {
     /// The config to use for transferring files.
     config: Arc<Config>,
     /// The HTTP client to use for transferring files.
-    client: ClientWithMiddleware,
-    /// The HTTP cache used by the client.
-    ///
-    /// This is `None` if caching is not enabled.
-    cache: Option<Arc<Cache<DefaultCacheStorage>>>,
+    client: HttpClient,
     /// The channel for sending transfer events.
     events: Option<broadcast::Sender<TransferEvent>>,
 }
 
 impl S3StorageBackend {
     /// Constructs a new S3 storage backend.
-    pub fn new(config: Config, events: Option<broadcast::Sender<TransferEvent>>) -> Self {
-        let (client, cache) = new_http_client(&config);
+    pub fn new(
+        config: Config,
+        client: HttpClient,
+        events: Option<broadcast::Sender<TransferEvent>>,
+    ) -> Self {
         Self {
             config: Arc::new(config),
             client,
-            cache,
             events,
         }
     }
@@ -494,7 +491,7 @@ impl StorageBackend for S3StorageBackend {
     }
 
     fn cache(&self) -> Option<&Cache<DefaultCacheStorage>> {
-        self.cache.as_deref()
+        self.client.cache()
     }
 
     fn events(&self) -> &Option<broadcast::Sender<TransferEvent>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 //! Implementation of cloud configuration.
 
 use std::num::NonZero;
-use std::path::PathBuf;
 use std::thread::available_parallelism;
 use std::time::Duration;
 
@@ -83,11 +82,6 @@ pub struct GoogleConfig {
 /// Configuration used in a cloud copy operation.
 #[derive(Debug, Clone, Default, Deserialize)]
 pub struct Config {
-    /// The cache directory to use for downloads.
-    ///
-    /// If `None`, downloads will not use a cache.
-    #[serde(default)]
-    pub cache_dir: Option<PathBuf>,
     /// If `link_to_cache` is `true`, then a downloaded file that is already
     /// present (and fresh) in the cache will be hard linked at the requested
     /// destination instead of copied.

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -7,6 +7,11 @@ use rand::Rng as _;
 /// An alphanumeric string generator.
 ///
 /// Every display of the generator will create a new random alphanumeric string.
+///
+/// By default, the displayed string will use all alphanumeric characters.
+///
+/// Use the alternate format (i.e. `{:#}`) to use only lowercase alphanumeric
+/// characters.
 #[derive(Clone, Copy)]
 pub struct Alphanumeric {
     /// The length of the alphanumeric string.
@@ -29,10 +34,11 @@ impl Default for Alphanumeric {
 
 impl fmt::Display for Alphanumeric {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let lowercase = f.alternate();
         for c in rand::rng()
             .sample_iter(&rand::distr::Alphanumeric)
             .take(self.length)
-            .map(|c| c.to_ascii_lowercase())
+            .map(|c| if lowercase { c.to_ascii_lowercase() } else { c })
         {
             write!(f, "{c}", c = c as char)?;
         }


### PR DESCRIPTION
This PR extracts out the internal HTTP client so that users of the library can configure their own HTTP client or share the client between all copy operations.

Also changes `Alphanumeric` to use upper and lower case characters by default; users can use the alternate format to use only lower case.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
