### PR TITLE
feat: implement a `rewrite_url` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Added
 
+* Added a `rewrite_url` for changing cloud storage schemed URLs into HTTP URLs ([#9](https://github.com/stjude-rust-labs/cloud-copy/pull/9)).
+
+## 0.1.0 - 08-19-2025
+
+#### Added
+
 * Added `HttpClient` for allowing reuse of an HTTP client between copy
   operations ([#7](https://github.com/stjude-rust-labs/cloud-copy/pull/7)).
 * Added support for linking files to the cache ([#6](https://github.com/stjude-rust-labs/cloud-copy/pull/6)).

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -1,5 +1,7 @@
 //! Implementation of storage backends.
 
+use std::borrow::Cow;
+
 use bytes::Bytes;
 use http_cache_stream_reqwest::Cache;
 use http_cache_stream_reqwest::storage::DefaultCacheStorage;
@@ -64,20 +66,20 @@ pub trait StorageBackend {
     /// `https` schemed URL.
     ///
     /// Otherwise, the given URL is returned as-is.
-    fn rewrite_url(&self, url: Url) -> Result<Url>;
+    fn rewrite_url<'a>(config: &Config, url: &'a Url) -> Result<Cow<'a, Url>>;
 
     /// Joins segments to a URL to form a new URL.
-    fn join_url<'a>(&self, url: Url, segments: impl Iterator<Item = &'a str>) -> Result<Url>;
+    fn join_url<'a>(&self, url: &Url, segments: impl Iterator<Item = &'a str>) -> Result<Url>;
 
     /// Sends a HEAD request for the given URL.
     ///
     /// Returns an error if the request was not successful.
-    fn head(&self, url: Url) -> impl Future<Output = Result<Response>> + Send;
+    fn head(&self, url: &Url) -> impl Future<Output = Result<Response>> + Send;
 
     /// Sends a GET request for the given URL.
     ///
     /// Returns an error if the request was not successful.
-    fn get(&self, url: Url) -> impl Future<Output = Result<Response>> + Send;
+    fn get(&self, url: &Url) -> impl Future<Output = Result<Response>> + Send;
 
     /// Sends a conditional ranged GET request for the given URL at the given
     /// start offset.
@@ -89,7 +91,7 @@ pub trait StorageBackend {
     /// not match (condition not met).
     fn get_at_offset(
         &self,
-        url: Url,
+        url: &Url,
         etag: &str,
         offset: u64,
     ) -> impl Future<Output = Result<Response>> + Send;
@@ -99,8 +101,8 @@ pub trait StorageBackend {
     /// Returns a list of relative paths from the given URL.
     ///
     /// If the given storage URL is not a directory, an empty list is returned.
-    fn walk(&self, url: Url) -> impl Future<Output = Result<Vec<String>>> + Send;
+    fn walk(&self, url: &Url) -> impl Future<Output = Result<Vec<String>>> + Send;
 
     /// Creates a new upload.
-    fn new_upload(&self, url: Url) -> impl Future<Output = Result<Self::Upload>> + Send;
+    fn new_upload(&self, url: &Url) -> impl Future<Output = Result<Self::Upload>> + Send;
 }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -69,17 +69,17 @@ pub trait StorageBackend {
     fn rewrite_url<'a>(config: &Config, url: &'a Url) -> Result<Cow<'a, Url>>;
 
     /// Joins segments to a URL to form a new URL.
-    fn join_url<'a>(&self, url: &Url, segments: impl Iterator<Item = &'a str>) -> Result<Url>;
+    fn join_url<'a>(&self, url: Url, segments: impl Iterator<Item = &'a str>) -> Result<Url>;
 
     /// Sends a HEAD request for the given URL.
     ///
     /// Returns an error if the request was not successful.
-    fn head(&self, url: &Url) -> impl Future<Output = Result<Response>> + Send;
+    fn head(&self, url: Url) -> impl Future<Output = Result<Response>> + Send;
 
     /// Sends a GET request for the given URL.
     ///
     /// Returns an error if the request was not successful.
-    fn get(&self, url: &Url) -> impl Future<Output = Result<Response>> + Send;
+    fn get(&self, url: Url) -> impl Future<Output = Result<Response>> + Send;
 
     /// Sends a conditional ranged GET request for the given URL at the given
     /// start offset.
@@ -91,7 +91,7 @@ pub trait StorageBackend {
     /// not match (condition not met).
     fn get_at_offset(
         &self,
-        url: &Url,
+        url: Url,
         etag: &str,
         offset: u64,
     ) -> impl Future<Output = Result<Response>> + Send;
@@ -101,8 +101,8 @@ pub trait StorageBackend {
     /// Returns a list of relative paths from the given URL.
     ///
     /// If the given storage URL is not a directory, an empty list is returned.
-    fn walk(&self, url: &Url) -> impl Future<Output = Result<Vec<String>>> + Send;
+    fn walk(&self, url: Url) -> impl Future<Output = Result<Vec<String>>> + Send;
 
     /// Creates a new upload.
-    fn new_upload(&self, url: &Url) -> impl Future<Output = Result<Self::Upload>> + Send;
+    fn new_upload(&self, url: Url) -> impl Future<Output = Result<Self::Upload>> + Send;
 }

--- a/src/backend/generic.rs
+++ b/src/backend/generic.rs
@@ -125,9 +125,8 @@ impl StorageBackend for GenericStorageBackend {
         Ok(Cow::Borrowed(url))
     }
 
-    fn join_url<'a>(&self, url: &Url, segments: impl Iterator<Item = &'a str>) -> Result<Url> {
+    fn join_url<'a>(&self, mut url: Url, segments: impl Iterator<Item = &'a str>) -> Result<Url> {
         // Append on the segments
-        let mut url = url.clone();
         {
             let mut existing = url.path_segments_mut().expect("url should have path");
             existing.pop_if_empty();
@@ -137,12 +136,12 @@ impl StorageBackend for GenericStorageBackend {
         Ok(url)
     }
 
-    async fn head(&self, url: &Url) -> Result<Response> {
+    async fn head(&self, url: Url) -> Result<Response> {
         debug!("sending HEAD request for `{url}`", url = url.display());
 
         let response = self
             .client
-            .head(url.clone())
+            .head(url)
             .header(header::USER_AGENT, USER_AGENT)
             .header(header::DATE, Utc::now().to_rfc2822())
             .send()
@@ -155,12 +154,12 @@ impl StorageBackend for GenericStorageBackend {
         Ok(response)
     }
 
-    async fn get(&self, url: &Url) -> Result<Response> {
+    async fn get(&self, url: Url) -> Result<Response> {
         debug!("sending GET request for `{url}`", url = url.display());
 
         let response = self
             .client
-            .get(url.clone())
+            .get(url)
             .header(header::USER_AGENT, USER_AGENT)
             .header(header::DATE, Utc::now().to_rfc2822())
             .send()
@@ -173,7 +172,7 @@ impl StorageBackend for GenericStorageBackend {
         Ok(response)
     }
 
-    async fn get_at_offset(&self, url: &Url, etag: &str, offset: u64) -> Result<Response> {
+    async fn get_at_offset(&self, url: Url, etag: &str, offset: u64) -> Result<Response> {
         debug!(
             "sending GET request at offset {offset} for `{url}`",
             url = url.display(),
@@ -181,7 +180,7 @@ impl StorageBackend for GenericStorageBackend {
 
         let response = self
             .client
-            .get(url.clone())
+            .get(url)
             .header(header::USER_AGENT, USER_AGENT)
             .header(header::DATE, Utc::now().to_rfc2822())
             .header(header::RANGE, format!("bytes={offset}-"))
@@ -204,12 +203,12 @@ impl StorageBackend for GenericStorageBackend {
         Ok(response)
     }
 
-    async fn walk(&self, _: &Url) -> Result<Vec<String>> {
+    async fn walk(&self, _: Url) -> Result<Vec<String>> {
         // The generic backend treats all URLs as files.
         Ok(Vec::default())
     }
 
-    async fn new_upload(&self, _: &Url) -> Result<Self::Upload> {
+    async fn new_upload(&self, _: Url) -> Result<Self::Upload> {
         panic!("generic storage backend cannot be used for uploading");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -647,17 +647,17 @@ pub async fn copy(
                 let destination = AzureBlobStorageBackend::rewrite_url(&config, &destination)?;
                 let transfer =
                     FileTransfer::new(AzureBlobStorageBackend::new(config, client, events), cancel);
-                transfer.upload(source, &destination).await
+                transfer.upload(source, destination.into_owned()).await
             } else if S3StorageBackend::is_supported_url(&config, &destination) {
                 let destination = S3StorageBackend::rewrite_url(&config, &destination)?;
                 let transfer =
                     FileTransfer::new(S3StorageBackend::new(config, client, events), cancel);
-                transfer.upload(source, &destination).await
+                transfer.upload(source, destination.into_owned()).await
             } else if GoogleStorageBackend::is_supported_url(&config, &destination) {
                 let destination = GoogleStorageBackend::rewrite_url(&config, &destination)?;
                 let transfer =
                     FileTransfer::new(GoogleStorageBackend::new(config, client, events), cancel);
-                transfer.upload(source, &destination).await
+                transfer.upload(source, destination.into_owned()).await
             } else {
                 Err(Error::UnsupportedUrl(destination.into_owned()))
             }
@@ -676,21 +676,21 @@ pub async fn copy(
                 let source = AzureBlobStorageBackend::rewrite_url(&config, &source)?;
                 let transfer =
                     FileTransfer::new(AzureBlobStorageBackend::new(config, client, events), cancel);
-                transfer.download(&source, destination).await
+                transfer.download(source.into_owned(), destination).await
             } else if S3StorageBackend::is_supported_url(&config, &source) {
                 let source = S3StorageBackend::rewrite_url(&config, &source)?;
                 let transfer =
                     FileTransfer::new(S3StorageBackend::new(config, client, events), cancel);
-                transfer.download(&source, destination).await
+                transfer.download(source.into_owned(), destination).await
             } else if GoogleStorageBackend::is_supported_url(&config, &source) {
                 let source = GoogleStorageBackend::rewrite_url(&config, &source)?;
                 let transfer =
                     FileTransfer::new(GoogleStorageBackend::new(config, client, events), cancel);
-                transfer.download(&source, destination).await
+                transfer.download(source.into_owned(), destination).await
             } else {
                 let transfer =
                     FileTransfer::new(GenericStorageBackend::new(config, client, events), cancel);
-                transfer.download(&source, destination).await
+                transfer.download(source.into_owned(), destination).await
             }
         }
         (Location::Url(source), Location::Url(destination)) => {


### PR DESCRIPTION
This commit implements a `rewrite_url` function at the root of the crate.

The function can be used to translate cloud-scheme URLs (e.g. `az://`, `s3://`, `gs://`) to their HTTP equivalent using the same translation logic that the `copy` function uses.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
