### PR TITLE
feat: show an indeterminate progress bar when event stream lags.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+#### Added
+
+* Display an indeterminate progress bar on event stream lag ([#19](https://github.com/stjude-rust-labs/cloud-copy/pull/19)).
+
 #### Fixed
 
 * Ensure required auth options for CLI ([#18](https://github.com/stjude-rust-labs/cloud-copy/pull/18)).

--- a/src/main.rs
+++ b/src/main.rs
@@ -211,7 +211,9 @@ async fn run(cancel: CancellationToken) -> Result<()> {
     let stats = handler.await.expect("failed to join events handler");
 
     // Print the statistics upon success
-    if result.is_ok() {
+    if result.is_ok()
+        && let Some(stats) = stats
+    {
         let delta = end - start;
         let seconds = delta.num_seconds();
 


### PR DESCRIPTION
This PR removes the warning for when the transfer event stream lags and instead removes all transfer progress bars and replaces it with a single spinning progress bar that will be displayed for as long as the event stream lives.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
