### PR TITLE
fix: issue HEAD request for Azure backend.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed the Azure backend not issuing a HEAD request for its `head` method
+  implementation ([#37](https://github.com/stjude-rust-labs/cloud-copy/pull/37)).
 * Fixed `walk` implementation to filter "directory" blobs from Azure Blob ([#36](https://github.com/stjude-rust-labs/cloud-copy/pull/36)).
 
 #### Changed

--- a/src/backend/azure.rs
+++ b/src/backend/azure.rs
@@ -570,7 +570,7 @@ impl StorageBackend for AzureBlobStorageBackend {
 
         let mut request = self
             .client
-            .get(url)
+            .head(url)
             .header(header::ACCEPT, "application/xml")
             .header(header::USER_AGENT, USER_AGENT)
             .header(header::DATE, Utc::now().to_http_date())


### PR DESCRIPTION
This PR fixes an issue where the `head` implementation of the Azure backend ends up sending a `GET` request instead of a `HEAD` request.

As the response body isn't read from places where the `head` method is called, this only impacts the server and not the functionality in `cloud-copy`.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
