### PR TITLE
fix: check for existence in uploads before calculating content digest.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 #### Fixed
 
+* Fixed upload content digests being calculated despite existence of the file
+  when requested not to overwrite ([#38](https://github.com/stjude-rust-labs/cloud-copy/pull/38)).
 * Fixed the Azure backend not issuing a HEAD request for its `head` method
   implementation ([#37](https://github.com/stjude-rust-labs/cloud-copy/pull/37)).
 * Fixed `walk` implementation to filter "directory" blobs from Azure Blob ([#36](https://github.com/stjude-rust-labs/cloud-copy/pull/36)).

--- a/src/backend/azure.rs
+++ b/src/backend/azure.rs
@@ -822,16 +822,6 @@ impl StorageBackend for AzureBlobStorageBackend {
             url = url.as_str()
         );
 
-        // Azure doesn't support conditional requests for `Put Block`.
-        // Therefore, we must issue a HEAD request for the blob if not overwriting.
-        // See: https://learn.microsoft.com/en-us/rest/api/storageservices/specifying-conditional-headers-for-blob-service-operations
-        if !self.config.overwrite() {
-            let response = self.head(url.clone(), false).await?;
-            if response.status() != StatusCode::NOT_FOUND {
-                return Err(Error::RemoteDestinationExists(url));
-            }
-        }
-
         Ok(AzureBlobUpload::new(
             self.config.clone(),
             self.client.clone(),

--- a/src/backend/google.rs
+++ b/src/backend/google.rs
@@ -790,15 +790,6 @@ impl StorageBackend for GoogleStorageBackend {
             url = url.as_str()
         );
 
-        // GCS doesn't support conditional requests for `CreateMultipartUpload`.
-        // Therefore, we must issue a HEAD request for the object if not overwriting.
-        if !self.config.overwrite() {
-            let response = self.head(url.clone(), false).await?;
-            if response.status() != StatusCode::NOT_FOUND {
-                return Err(Error::RemoteDestinationExists(url));
-            }
-        }
-
         debug!("sending POST request for `{url}`", url = url.display());
 
         let mut create = url.clone();

--- a/src/backend/s3.rs
+++ b/src/backend/s3.rs
@@ -868,16 +868,6 @@ impl StorageBackend for S3StorageBackend {
             url = url.as_str()
         );
 
-        // S3 doesn't support conditional requests for `CreateMultipartUpload`.
-        // Therefore, we must issue a HEAD request for the object if not overwriting.
-        // See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html#conditional-write-key-names
-        if !self.config.overwrite() {
-            let response = self.head(url.clone(), false).await?;
-            if response.status() != StatusCode::NOT_FOUND {
-                return Err(Error::RemoteDestinationExists(url));
-            }
-        }
-
         debug!("sending POST request for `{url}`", url = url.display());
 
         let mut create = url.clone();

--- a/src/transfer.rs
+++ b/src/transfer.rs
@@ -908,6 +908,15 @@ where
 
     /// Uploads the given file to the given destination.
     async fn upload_file(&self, source: &Path, destination: Url, file_size: u64) -> Result<()> {
+        // Prior to uploading the file, ensure it doesn't already exist if not
+        // overwriting
+        if !self.inner.backend.config().overwrite() {
+            let response = self.inner.backend.head(destination.clone(), false).await?;
+            if response.status() != StatusCode::NOT_FOUND {
+                return Err(Error::RemoteDestinationExists(destination));
+            }
+        }
+
         // Calculate the content digest
         let digest = self
             .inner


### PR DESCRIPTION
This PR moves an existence check that is present in every backend
that supports uploading files to before content digests are calculated.

By doing so, the copy operation will not waste time calculating a
content digest for a file that cannot be overwritten as an error will be
returned anyway.

Before submitting this PR, please make sure:

- [x] You have added a few sentences describing the PR here.
- [x] You have added yourself or the appropriate individual as the assignee.
- [x] You have added at least one relevant code reviewer to the PR.
- [x] Your code builds clean without any errors or warnings.
- [x] You have added tests (when appropriate).
- [x] You have updated the README or other documentation to account for these
      changes (when appropriate).
- [x] You have added an entry to the relevant `CHANGELOG.md` (see
      ["keep a changelog"] for more information).
- [x] Your commit messages follow the [conventional commit] style.

[conventional commit]: https://www.conventionalcommits.org/en/v1.0.0/#summary
["keep a changelog"]: https://keepachangelog.com/en/1.0.0/
